### PR TITLE
[#15]開発環境URLのポート番号を8081に変更しているとvue-cliのhot reloadが動作しないため、8080を利用するように変更

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   vue-app:
     image: damehal/devenv-vuecli
     ports:  # ローカルホストURL: http://localhost:8081/
-      - "8081:8080"
+      - "8080:8080"
     volumes:  # 共有するディレクトリをマウント
       - ./app:/home/nodeuser/sharing-lunch
     container_name: sharing-lunch


### PR DESCRIPTION
closed #15 